### PR TITLE
deps: Upgrade MailCatcher runtime

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -30,6 +30,62 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@v2
 
+      - name: Build smoke test image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          load: true
+          tags: mailcatcher:smoke-test
+
+      - name: Smoke test
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          image="mailcatcher:smoke-test"
+          container="mailcatcher-smoke-test"
+
+          cleanup() {
+            status=$?
+            if [[ "$status" -ne 0 ]]; then
+              docker logs "$container" || true
+            fi
+            docker rm --force "$container" >/dev/null 2>&1 || true
+            exit "$status"
+          }
+          trap cleanup EXIT
+
+          [[ "$(docker run --rm "$image" ruby --version)" == "ruby 4.0.6"* ]]
+          [[ "$(docker run --rm "$image" mailcatcher --version)" == "MailCatcher v0.10.0" ]]
+          docker run --rm "$image" sh -c \
+            'apk info --exists libstdc++ sqlite-libs && ! apk info --exists .build-deps'
+
+          docker run --detach --name "$container" \
+            --publish 127.0.0.1:11025:1025 \
+            --publish 127.0.0.1:11080:1080 \
+            "$image"
+
+          for attempt in {1..30}; do
+            if curl --fail --silent http://127.0.0.1:11080/ >/dev/null; then
+              break
+            fi
+            if [[ "$attempt" -eq 30 ]]; then
+              echo "MailCatcher HTTP endpoint did not become ready" >&2
+              exit 1
+            fi
+            sleep 2
+          done
+
+          printf 'From: smoke-sender@example.test\r\nTo: smoke-recipient@example.test\r\nSubject: MailCatcher smoke test\r\n\r\nRuntime validation\r\n' \
+            | curl --fail --silent --show-error \
+                --url smtp://127.0.0.1:11025 \
+                --mail-from smoke-sender@example.test \
+                --mail-rcpt smoke-recipient@example.test \
+                --upload-file -
+
+          curl --fail --silent --show-error http://127.0.0.1:11080/messages \
+            | grep --fixed-strings --quiet '"subject":"MailCatcher smoke test"'
+
       - name: Login to Github Container Registry
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7.6-alpine3.15
+FROM ruby:4.0.6-alpine3.24
 LABEL maintainer="Marcelo Wiebbelling <mrodrigow@gmail.com>"
 RUN set -xe \
     && apk add --no-cache \
@@ -7,7 +7,7 @@ RUN set -xe \
     && apk add --no-cache --virtual .build-deps \
         build-base \
         sqlite-dev \
-    && gem install mailcatcher -v 0.8.2 -N \
+    && gem install mailcatcher -v 0.10.0 -N \
     && apk del .build-deps
 EXPOSE 1025
 EXPOSE 1080

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 # Mailcatcher
 Lightweight multiarchitecture [Mailcatcher](https://mailcatcher.me/) Docker image
 
-Based on [Alpine Linux](https://www.alpinelinux.org/), it generates a very small footprint (~27Mb) docker image.
+Based on [Alpine Linux](https://www.alpinelinux.org/), it keeps the Docker image footprint small.
 ## Usage
 
 Pull it:


### PR DESCRIPTION
Upgrade the container to MailCatcher 0.10.0 on Ruby 4.0.6 and Alpine 3.24. Add CI smoke validation for embedded versions, runtime package cleanup, HTTP startup, SMTP delivery, and retrieval through the MailCatcher API.

The existing image uses end-of-life Ruby 2.7 and Alpine 3.15 with MailCatcher 0.8.2. Moving to current upstream releases reduces exposure to outdated runtime components while preserving the existing command, ports, registries, and amd64, arm64, and arm/v7 publication targets.

A conservative Ruby 3.4 base was considered, but the latest stable stack was selected after successful native and multiarchitecture builds. The stale fixed image-size claim is removed because the resulting size varies with upstream layers.

Validation completed successfully for the native SMTP-to-HTTP flow and for builds on all three published architectures. The arm/v7 native SQLite compilation is slower under emulation but completes successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated container smoke tests that verify startup, HTTP readiness, SMTP email delivery, and message visibility through the web interface.
  * Updated the Docker image to use newer Ruby, Alpine Linux, and MailCatcher versions.

* **Documentation**
  * Revised the README to provide a general description of the Alpine-based image footprint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->