### PR TITLE
ci: Drop legacy ARMv7 image

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -68,7 +68,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta_mailcatcher.outputs.tags }}
           labels: ${{ steps.meta_mailcatcher.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 ![Docker Pulls](https://img.shields.io/docker/pulls/marcelorodrigo/mailcatcher)
 ![Linux AMD64](https://img.shields.io/badge/linux-amd64-orange)
 ![Linux ARM64](https://img.shields.io/badge/linux-arm64-orange)
-![Linux ARMV7](https://img.shields.io/badge/linux-armv7-orange)
 [![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=marcelorodrigo_mailcatcher&metric=vulnerabilities)](https://sonarcloud.io/summary/new_code?id=marcelorodrigo_mailcatcher)
 [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=marcelorodrigo_mailcatcher&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=marcelorodrigo_mailcatcher)
 


### PR DESCRIPTION
Limit published Docker images to the two mainstream modern architectures: AMD64 and ARM64.

This removes the legacy ARMv7 target from the multi-platform build and removes its architecture badge from the README, keeping the documentation aligned with the published image manifest.