### PR TITLE
ci: Upgrade Docker build-push action to v7

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -31,7 +31,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Build smoke test image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v7
         with:
           context: .
           load: true
@@ -121,7 +121,7 @@ jobs:
             type=semver,pattern={{major}}
             type=sha
       - name: Build and push
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64,linux/arm/v7


### PR DESCRIPTION
Update both Docker container-build steps from `docker/build-push-action@v3` to the current v7 major.

This removes the workflow dependency on the stale v3 release while preserving the existing smoke-test and multi-platform build configuration.