### PR TITLE
fix(docker): run MailCatcher as non-root

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -74,6 +74,7 @@ jobs:
 
           [[ "$(docker run --rm "$image" ruby --version)" == "ruby ${ruby_version}"* ]]
           [[ "$(docker run --rm "$image" mailcatcher --version)" == "MailCatcher v${mailcatcher_version}" ]]
+          [[ "$(docker run --rm "$image" id -un)" == "mailcatcher" ]]
           docker run --rm "$image" sh -c \
             'apk info --exists libstdc++ sqlite-libs && ! apk info --exists .build-deps'
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,9 @@ RUN set -xe \
         build-base \
         sqlite-dev \
     && gem install mailcatcher -v "${MAILCATCHER_VERSION}" -N \
-    && apk del .build-deps
+    && apk del .build-deps \
+    && adduser -S -D -H mailcatcher
 EXPOSE 1025
 EXPOSE 1080
+USER mailcatcher
 CMD ["sh", "-c", "mailcatcher --no-quit --foreground --ip=0.0.0.0"]


### PR DESCRIPTION
Run MailCatcher under a dedicated unprivileged Alpine system user in the final image.\n\nThis removes root execution from the default container runtime while keeping the existing command and non-privileged port bindings unchanged. The CI smoke test now also confirms the default container identity, alongside the existing startup, SMTP, and HTTP checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Reliability**
  * Docker containers now run as a non-root `mailcatcher` user, improving runtime isolation.
  * Docker smoke tests verify the container uses the intended user.
  * Existing exposed ports remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->